### PR TITLE
v1.1.42: 浏览页滑动/导航修复 + 视频软解优化 + 自定义主题色。

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -1623,7 +1623,7 @@
   "@msg508b005e": {
     "description": "ui\\screens\\more_settings_screen.dart"
   },
-  "msg508b005e": "أخضر غابي",
+  "msg508b005e": "أخضر ليموني",
   "@msgefdde083": {
     "description": "ui\\screens\\more_settings_screen.dart"
   },
@@ -3177,7 +3177,7 @@
   "ui_remember_filter": "تذكر الفلتر",
   "msg_remember_filter_desc": "فعال لهذه الجلسة فقط عند الإيقاف",
   "ui_app_icon": "أيقونة التطبيق",
-  "ui_emerald_green": "أخضر زمردي",
+  "ui_emerald_green": "سماوي نيون",
   "ui_deep_red": "أحمر داكن",
   "ui_square": "مربع",
   "ui_circle": "دائرة",
@@ -6593,5 +6593,17 @@
   "vt_silent_fallback": "تمت محاولة التثبيت الصامت لكن دون إذن؛ سيتم استخدام مثبّت النظام",
   "@vt_silent_fallback": {
     "description": "silent install fallback to system installer notice"
+  },
+  "ui_nav_back": "رجوع",
+  "@ui_nav_back": {
+    "description": "File browser action bar: go back in navigation history"
+  },
+  "ui_nav_forward": "التالي",
+  "@ui_nav_forward": {
+    "description": "File browser action bar: go forward in navigation history"
+  },
+  "ui_custom_theme": "مخصص",
+  "@ui_custom_theme": {
+    "description": "ui\\screens\\more_settings_screen.dart"
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1620,7 +1620,7 @@
   "@msg508b005e": {
     "description": "ui\\screens\\more_settings_screen.dart"
   },
-  "msg508b005e": "Wald-Grün",
+  "msg508b005e": "Limettengrün",
   "@msgefdde083": {
     "description": "ui\\screens\\more_settings_screen.dart"
   },
@@ -3174,7 +3174,7 @@
   "ui_remember_filter": "Filter merken",
   "msg_remember_filter_desc": "Nur für diese Sitzung, wenn deaktiviert",
   "ui_app_icon": "App-Symbol",
-  "ui_emerald_green": "Smaragdgrün",
+  "ui_emerald_green": "Neon-Cyan",
   "ui_deep_red": "Dunkelrot",
   "ui_square": "Quadrat",
   "ui_circle": "Kreis",
@@ -6590,5 +6590,17 @@
   "vt_silent_fallback": "Stille Installation versucht, aber ohne Berechtigung; Systeminstaller wird verwendet",
   "@vt_silent_fallback": {
     "description": "silent install fallback to system installer notice"
+  },
+  "ui_nav_back": "Zurück",
+  "@ui_nav_back": {
+    "description": "File browser action bar: go back in navigation history"
+  },
+  "ui_nav_forward": "Weiter",
+  "@ui_nav_forward": {
+    "description": "File browser action bar: go forward in navigation history"
+  },
+  "ui_custom_theme": "Benutzerdefiniert",
+  "@ui_custom_theme": {
+    "description": "ui\\screens\\more_settings_screen.dart"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1630,7 +1630,7 @@
   "@msg508b005e": {
     "description": "ui\\screens\\more_settings_screen.dart"
   },
-  "msg508b005e": "Forest Green",
+  "msg508b005e": "Lime Green",
   "@msgefdde083": {
     "description": "ui\\screens\\more_settings_screen.dart"
   },
@@ -3184,7 +3184,7 @@
   "ui_remember_filter": "Remember filter",
   "msg_remember_filter_desc": "Effective only for this session when off",
   "ui_app_icon": "App Icon",
-  "ui_emerald_green": "Emerald Green",
+  "ui_emerald_green": "Neon Cyan",
   "ui_deep_red": "Deep Red",
   "ui_square": "Square",
   "ui_circle": "Circle",
@@ -6659,5 +6659,17 @@
   "vt_silent_fallback": "Silent install attempted but lacked permission; using the system installer",
   "@vt_silent_fallback": {
     "description": "silent install fallback to system installer notice"
+  },
+  "ui_nav_back": "Back",
+  "@ui_nav_back": {
+    "description": "File browser action bar: go back in navigation history"
+  },
+  "ui_nav_forward": "Forward",
+  "@ui_nav_forward": {
+    "description": "File browser action bar: go forward in navigation history"
+  },
+  "ui_custom_theme": "Custom",
+  "@ui_custom_theme": {
+    "description": "ui\\screens\\more_settings_screen.dart"
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1623,7 +1623,7 @@
   "@msg508b005e": {
     "description": "ui\\screens\\more_settings_screen.dart"
   },
-  "msg508b005e": "Verde Bosque",
+  "msg508b005e": "Verde lima",
   "@msgefdde083": {
     "description": "ui\\screens\\more_settings_screen.dart"
   },
@@ -3177,7 +3177,7 @@
   "ui_remember_filter": "Recordar filtro",
   "msg_remember_filter_desc": "Solo efectivo para esta sesión si está desactivado",
   "ui_app_icon": "Icono de la App",
-  "ui_emerald_green": "Verde Esmeralda",
+  "ui_emerald_green": "Cian neón",
   "ui_deep_red": "Rojo Profundo",
   "ui_square": "Cuadrado",
   "ui_circle": "Círculo",
@@ -6593,5 +6593,17 @@
   "vt_silent_fallback": "Se intentó la instalación silenciosa, pero faltó permiso; se usará el instalador del sistema",
   "@vt_silent_fallback": {
     "description": "silent install fallback to system installer notice"
+  },
+  "ui_nav_back": "Atrás",
+  "@ui_nav_back": {
+    "description": "File browser action bar: go back in navigation history"
+  },
+  "ui_nav_forward": "Adelante",
+  "@ui_nav_forward": {
+    "description": "File browser action bar: go forward in navigation history"
+  },
+  "ui_custom_theme": "Personalizado",
+  "@ui_custom_theme": {
+    "description": "ui\\screens\\more_settings_screen.dart"
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1623,7 +1623,7 @@
   "@msg508b005e": {
     "description": "ui\\screens\\more_settings_screen.dart"
   },
-  "msg508b005e": "Vert forêt",
+  "msg508b005e": "Vert citron vert",
   "@msgefdde083": {
     "description": "ui\\screens\\more_settings_screen.dart"
   },
@@ -3177,7 +3177,7 @@
   "ui_remember_filter": "Mémoriser le filtre",
   "msg_remember_filter_desc": "Effectif uniquement pour cette session si désactivé",
   "ui_app_icon": "Icône de l'application",
-  "ui_emerald_green": "Vert émeraude",
+  "ui_emerald_green": "Cyan néon",
   "ui_deep_red": "Rouge foncé",
   "ui_square": "Carré",
   "ui_circle": "Cercle",
@@ -6593,5 +6593,17 @@
   "vt_silent_fallback": "Installation silencieuse tentée mais sans permission ; installation par le programme système",
   "@vt_silent_fallback": {
     "description": "silent install fallback to system installer notice"
+  },
+  "ui_nav_back": "Retour",
+  "@ui_nav_back": {
+    "description": "File browser action bar: go back in navigation history"
+  },
+  "ui_nav_forward": "Suivant",
+  "@ui_nav_forward": {
+    "description": "File browser action bar: go forward in navigation history"
+  },
+  "ui_custom_theme": "Personnalisé",
+  "@ui_custom_theme": {
+    "description": "ui\\screens\\more_settings_screen.dart"
   }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1627,7 +1627,7 @@
   "@msg508b005e": {
     "description": "ui\\screens\\more_settings_screen.dart"
   },
-  "msg508b005e": "フォレストグリーン",
+  "msg508b005e": "ライムグリーン",
   "@msgefdde083": {
     "description": "ui\\screens\\more_settings_screen.dart"
   },
@@ -3181,7 +3181,7 @@
   "ui_remember_filter": "フィルターを記憶",
   "msg_remember_filter_desc": "オフの場合は今回のみ有効",
   "ui_app_icon": "アプリアイコン",
-  "ui_emerald_green": "エメラルドグリーン",
+  "ui_emerald_green": "ネオンシアン",
   "ui_deep_red": "ディープレッド",
   "ui_square": "角形",
   "ui_circle": "円形",
@@ -6597,5 +6597,17 @@
   "vt_silent_fallback": "サイレントインストールを試みましたが権限が不足していました。システムインストーラーを使用します",
   "@vt_silent_fallback": {
     "description": "silent install fallback to system installer notice"
+  },
+  "ui_nav_back": "戻る",
+  "@ui_nav_back": {
+    "description": "File browser action bar: go back in navigation history"
+  },
+  "ui_nav_forward": "進む",
+  "@ui_nav_forward": {
+    "description": "File browser action bar: go forward in navigation history"
+  },
+  "ui_custom_theme": "カスタム",
+  "@ui_custom_theme": {
+    "description": "ui\\screens\\more_settings_screen.dart"
   }
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1623,7 +1623,7 @@
   "@msg508b005e": {
     "description": "ui\\screens\\more_settings_screen.dart"
   },
-  "msg508b005e": "포레스트 그린",
+  "msg508b005e": "라임 그린",
   "@msgefdde083": {
     "description": "ui\\screens\\more_settings_screen.dart"
   },
@@ -3177,7 +3177,7 @@
   "ui_remember_filter": "필터 기억",
   "msg_remember_filter_desc": "꺼두면 이번 세션에만 적용",
   "ui_app_icon": "앱 아이콘",
-  "ui_emerald_green": "에메랄드 그린",
+  "ui_emerald_green": "네온 시안",
   "ui_deep_red": "딥 레드",
   "ui_square": "사각형",
   "ui_circle": "원형",
@@ -6593,5 +6593,17 @@
   "vt_silent_fallback": "자동 설치를 시도했지만 권한이 부족합니다. 시스템 설치 프로그램을 사용합니다",
   "@vt_silent_fallback": {
     "description": "silent install fallback to system installer notice"
+  },
+  "ui_nav_back": "뒤로",
+  "@ui_nav_back": {
+    "description": "File browser action bar: go back in navigation history"
+  },
+  "ui_nav_forward": "앞으로",
+  "@ui_nav_forward": {
+    "description": "File browser action bar: go forward in navigation history"
+  },
+  "ui_custom_theme": "사용자 정의",
+  "@ui_custom_theme": {
+    "description": "ui\\screens\\more_settings_screen.dart"
   }
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1623,7 +1623,7 @@
   "@msg508b005e": {
     "description": "ui\\screens\\more_settings_screen.dart"
   },
-  "msg508b005e": "Лесно-Зелёный",
+  "msg508b005e": "Лаймовый зелёный",
   "@msgefdde083": {
     "description": "ui\\screens\\more_settings_screen.dart"
   },
@@ -3177,7 +3177,7 @@
   "ui_remember_filter": "Запомнить фильтр",
   "msg_remember_filter_desc": "Действует только для текущего сеанса, если выключено",
   "ui_app_icon": "Значок Приложения",
-  "ui_emerald_green": "Изумрудно-Зелёный",
+  "ui_emerald_green": "Неоновый циан",
   "ui_deep_red": "Глубокий Красный",
   "ui_square": "Квадрат",
   "ui_circle": "Круг",
@@ -6593,5 +6593,17 @@
   "vt_silent_fallback": "Попытка тихой установки не удалась из-за прав; используется системный установщик",
   "@vt_silent_fallback": {
     "description": "silent install fallback to system installer notice"
+  },
+  "ui_nav_back": "Назад",
+  "@ui_nav_back": {
+    "description": "File browser action bar: go back in navigation history"
+  },
+  "ui_nav_forward": "Вперёд",
+  "@ui_nav_forward": {
+    "description": "File browser action bar: go forward in navigation history"
+  },
+  "ui_custom_theme": "Настраиваемый",
+  "@ui_custom_theme": {
+    "description": "ui\\screens\\more_settings_screen.dart"
   }
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1656,7 +1656,7 @@
   "@msgd58d230a": {
     "description": "ui\\screens\\more_settings_screen.dart"
   },
-  "msg508b005e": "森林绿",
+  "msg508b005e": "青柠绿",
   "@msg508b005e": {
     "description": "ui\\screens\\more_settings_screen.dart"
   },
@@ -3266,7 +3266,7 @@
   "ui_remember_filter": "记住过滤",
   "msg_remember_filter_desc": "关闭后仅本次生效",
   "ui_app_icon": "应用图标",
-  "ui_emerald_green": "翠绿",
+  "ui_emerald_green": "霓虹青",
   "ui_deep_red": "深红",
   "ui_square": "方形",
   "ui_circle": "圆形",
@@ -6880,5 +6880,17 @@
   "vt_silent_fallback": "已尝试静默安装，权限不足，改用系统安装器",
   "@vt_silent_fallback": {
     "description": "silent install fallback to system installer notice"
+  },
+  "ui_nav_back": "后退",
+  "@ui_nav_back": {
+    "description": "File browser action bar: go back in navigation history"
+  },
+  "ui_nav_forward": "前进",
+  "@ui_nav_forward": {
+    "description": "File browser action bar: go forward in navigation history"
+  },
+  "ui_custom_theme": "自定义",
+  "@ui_custom_theme": {
+    "description": "ui\\screens\\more_settings_screen.dart"
   }
 }

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -1656,7 +1656,7 @@
   "@msgd58d230a": {
     "description": "ui\\screens\\more_settings_screen.dart"
   },
-  "msg508b005e": "森林綠",
+  "msg508b005e": "青檸綠",
   "@msg508b005e": {
     "description": "ui\\screens\\more_settings_screen.dart"
   },
@@ -3248,7 +3248,7 @@
   "ui_remember_filter": "記住過濾",
   "msg_remember_filter_desc": "關閉後僅本次生效",
   "ui_app_icon": "應用圖示",
-  "ui_emerald_green": "翠綠",
+  "ui_emerald_green": "霓虹青",
   "ui_deep_red": "深紅",
   "ui_square": "方形",
   "ui_circle": "圓形",
@@ -6741,5 +6741,17 @@
   "vt_silent_fallback": "已嘗試靜默安裝，權限不足，改用系統安裝程式",
   "@vt_silent_fallback": {
     "description": "silent install fallback to system installer notice"
+  },
+  "ui_nav_back": "後退",
+  "@ui_nav_back": {
+    "description": "File browser action bar: go back in navigation history"
+  },
+  "ui_nav_forward": "前進",
+  "@ui_nav_forward": {
+    "description": "File browser action bar: go forward in navigation history"
+  },
+  "ui_custom_theme": "自訂",
+  "@ui_custom_theme": {
+    "description": "ui\\screens\\more_settings_screen.dart"
   }
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -2551,7 +2551,7 @@ abstract class L10n {
   /// ui\screens\more_settings_screen.dart
   ///
   /// In zh, this message translates to:
-  /// **'森林绿'**
+  /// **'青柠绿'**
   String get msg508b005e;
 
   /// ui\screens\more_settings_screen.dart
@@ -5293,7 +5293,7 @@ abstract class L10n {
   /// No description provided for @ui_emerald_green.
   ///
   /// In zh, this message translates to:
-  /// **'翠绿'**
+  /// **'霓虹青'**
   String get ui_emerald_green;
 
   /// No description provided for @ui_deep_red.
@@ -11775,6 +11775,24 @@ abstract class L10n {
   /// In zh, this message translates to:
   /// **'已尝试静默安装，权限不足，改用系统安装器'**
   String get vt_silent_fallback;
+
+  /// File browser action bar: go back in navigation history
+  ///
+  /// In zh, this message translates to:
+  /// **'后退'**
+  String get ui_nav_back;
+
+  /// File browser action bar: go forward in navigation history
+  ///
+  /// In zh, this message translates to:
+  /// **'前进'**
+  String get ui_nav_forward;
+
+  /// ui\screens\more_settings_screen.dart
+  ///
+  /// In zh, this message translates to:
+  /// **'自定义'**
+  String get ui_custom_theme;
 }
 
 class _L10nDelegate extends LocalizationsDelegate<L10n> {

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -1349,7 +1349,7 @@ class L10nAr extends L10n {
   String get msgd58d230a => 'أزرق ياقوتي';
 
   @override
-  String get msg508b005e => 'أخضر غابي';
+  String get msg508b005e => 'أخضر ليموني';
 
   @override
   String get msgefdde083 => 'خوخي غروب';
@@ -2852,7 +2852,7 @@ class L10nAr extends L10n {
   String get ui_app_icon => 'أيقونة التطبيق';
 
   @override
-  String get ui_emerald_green => 'أخضر زمردي';
+  String get ui_emerald_green => 'سماوي نيون';
 
   @override
   String get ui_deep_red => 'أحمر داكن';
@@ -6550,4 +6550,13 @@ class L10nAr extends L10n {
   @override
   String get vt_silent_fallback =>
       'تمت محاولة التثبيت الصامت لكن دون إذن؛ سيتم استخدام مثبّت النظام';
+
+  @override
+  String get ui_nav_back => 'رجوع';
+
+  @override
+  String get ui_nav_forward => 'التالي';
+
+  @override
+  String get ui_custom_theme => 'مخصص';
 }

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -1379,7 +1379,7 @@ class L10nDe extends L10n {
   String get msgd58d230a => 'Saphir-Blau';
 
   @override
-  String get msg508b005e => 'Wald-Grün';
+  String get msg508b005e => 'Limettengrün';
 
   @override
   String get msgefdde083 => 'Sonnenuntergang-Pfirsich';
@@ -2900,7 +2900,7 @@ class L10nDe extends L10n {
   String get ui_app_icon => 'App-Symbol';
 
   @override
-  String get ui_emerald_green => 'Smaragdgrün';
+  String get ui_emerald_green => 'Neon-Cyan';
 
   @override
   String get ui_deep_red => 'Dunkelrot';
@@ -6639,4 +6639,13 @@ class L10nDe extends L10n {
   @override
   String get vt_silent_fallback =>
       'Stille Installation versucht, aber ohne Berechtigung; Systeminstaller wird verwendet';
+
+  @override
+  String get ui_nav_back => 'Zurück';
+
+  @override
+  String get ui_nav_forward => 'Weiter';
+
+  @override
+  String get ui_custom_theme => 'Benutzerdefiniert';
 }

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1355,7 +1355,7 @@ class L10nEn extends L10n {
   String get msgd58d230a => 'Sapphire Blue';
 
   @override
-  String get msg508b005e => 'Forest Green';
+  String get msg508b005e => 'Lime Green';
 
   @override
   String get msgefdde083 => 'Sunset Peach';
@@ -2857,7 +2857,7 @@ class L10nEn extends L10n {
   String get ui_app_icon => 'App Icon';
 
   @override
-  String get ui_emerald_green => 'Emerald Green';
+  String get ui_emerald_green => 'Neon Cyan';
 
   @override
   String get ui_deep_red => 'Deep Red';
@@ -6585,4 +6585,13 @@ class L10nEn extends L10n {
   @override
   String get vt_silent_fallback =>
       'Silent install attempted but lacked permission; using the system installer';
+
+  @override
+  String get ui_nav_back => 'Back';
+
+  @override
+  String get ui_nav_forward => 'Forward';
+
+  @override
+  String get ui_custom_theme => 'Custom';
 }

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -1389,7 +1389,7 @@ class L10nEs extends L10n {
   String get msgd58d230a => 'Azul Zafiro';
 
   @override
-  String get msg508b005e => 'Verde Bosque';
+  String get msg508b005e => 'Verde lima';
 
   @override
   String get msgefdde083 => 'Melocotón Atardecer';
@@ -2919,7 +2919,7 @@ class L10nEs extends L10n {
   String get ui_app_icon => 'Icono de la App';
 
   @override
-  String get ui_emerald_green => 'Verde Esmeralda';
+  String get ui_emerald_green => 'Cian neón';
 
   @override
   String get ui_deep_red => 'Rojo Profundo';
@@ -6656,4 +6656,13 @@ class L10nEs extends L10n {
   @override
   String get vt_silent_fallback =>
       'Se intentó la instalación silenciosa, pero faltó permiso; se usará el instalador del sistema';
+
+  @override
+  String get ui_nav_back => 'Atrás';
+
+  @override
+  String get ui_nav_forward => 'Adelante';
+
+  @override
+  String get ui_custom_theme => 'Personalizado';
 }

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -1386,7 +1386,7 @@ class L10nFr extends L10n {
   String get msgd58d230a => 'Bleu saphir';
 
   @override
-  String get msg508b005e => 'Vert forêt';
+  String get msg508b005e => 'Vert citron vert';
 
   @override
   String get msgefdde083 => 'Pêche de coucher de soleil';
@@ -2920,7 +2920,7 @@ class L10nFr extends L10n {
   String get ui_app_icon => 'Icône de l\'application';
 
   @override
-  String get ui_emerald_green => 'Vert émeraude';
+  String get ui_emerald_green => 'Cyan néon';
 
   @override
   String get ui_deep_red => 'Rouge foncé';
@@ -6671,4 +6671,13 @@ class L10nFr extends L10n {
   @override
   String get vt_silent_fallback =>
       'Installation silencieuse tentée mais sans permission ; installation par le programme système';
+
+  @override
+  String get ui_nav_back => 'Retour';
+
+  @override
+  String get ui_nav_forward => 'Suivant';
+
+  @override
+  String get ui_custom_theme => 'Personnalisé';
 }

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -1291,7 +1291,7 @@ class L10nJa extends L10n {
   String get msgd58d230a => 'サファイアブルー';
 
   @override
-  String get msg508b005e => 'フォレストグリーン';
+  String get msg508b005e => 'ライムグリーン';
 
   @override
   String get msgefdde083 => 'サンセットピーチ';
@@ -2769,7 +2769,7 @@ class L10nJa extends L10n {
   String get ui_app_icon => 'アプリアイコン';
 
   @override
-  String get ui_emerald_green => 'エメラルドグリーン';
+  String get ui_emerald_green => 'ネオンシアン';
 
   @override
   String get ui_deep_red => 'ディープレッド';
@@ -6386,4 +6386,13 @@ class L10nJa extends L10n {
   @override
   String get vt_silent_fallback =>
       'サイレントインストールを試みましたが権限が不足していました。システムインストーラーを使用します';
+
+  @override
+  String get ui_nav_back => '戻る';
+
+  @override
+  String get ui_nav_forward => '進む';
+
+  @override
+  String get ui_custom_theme => 'カスタム';
 }

--- a/lib/l10n/generated/app_localizations_ko.dart
+++ b/lib/l10n/generated/app_localizations_ko.dart
@@ -1289,7 +1289,7 @@ class L10nKo extends L10n {
   String get msgd58d230a => '사파이어 블루';
 
   @override
-  String get msg508b005e => '포레스트 그린';
+  String get msg508b005e => '라임 그린';
 
   @override
   String get msgefdde083 => '선셋 피치';
@@ -2766,7 +2766,7 @@ class L10nKo extends L10n {
   String get ui_app_icon => '앱 아이콘';
 
   @override
-  String get ui_emerald_green => '에메랄드 그린';
+  String get ui_emerald_green => '네온 시안';
 
   @override
   String get ui_deep_red => '딥 레드';
@@ -6380,4 +6380,13 @@ class L10nKo extends L10n {
 
   @override
   String get vt_silent_fallback => '자동 설치를 시도했지만 권한이 부족합니다. 시스템 설치 프로그램을 사용합니다';
+
+  @override
+  String get ui_nav_back => '뒤로';
+
+  @override
+  String get ui_nav_forward => '앞으로';
+
+  @override
+  String get ui_custom_theme => '사용자 정의';
 }

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -1383,7 +1383,7 @@ class L10nRu extends L10n {
   String get msgd58d230a => 'Сапфирово-Синий';
 
   @override
-  String get msg508b005e => 'Лесно-Зелёный';
+  String get msg508b005e => 'Лаймовый зелёный';
 
   @override
   String get msgefdde083 => 'Персиковый Закат';
@@ -2905,7 +2905,7 @@ class L10nRu extends L10n {
   String get ui_app_icon => 'Значок Приложения';
 
   @override
-  String get ui_emerald_green => 'Изумрудно-Зелёный';
+  String get ui_emerald_green => 'Неоновый циан';
 
   @override
   String get ui_deep_red => 'Глубокий Красный';
@@ -6636,4 +6636,13 @@ class L10nRu extends L10n {
   @override
   String get vt_silent_fallback =>
       'Попытка тихой установки не удалась из-за прав; используется системный установщик';
+
+  @override
+  String get ui_nav_back => 'Назад';
+
+  @override
+  String get ui_nav_forward => 'Вперёд';
+
+  @override
+  String get ui_custom_theme => 'Настраиваемый';
 }

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -1288,7 +1288,7 @@ class L10nZh extends L10n {
   String get msgd58d230a => '蓝宝石';
 
   @override
-  String get msg508b005e => '森林绿';
+  String get msg508b005e => '青柠绿';
 
   @override
   String get msgefdde083 => '日落桃';
@@ -2758,7 +2758,7 @@ class L10nZh extends L10n {
   String get ui_app_icon => '应用图标';
 
   @override
-  String get ui_emerald_green => '翠绿';
+  String get ui_emerald_green => '霓虹青';
 
   @override
   String get ui_deep_red => '深红';
@@ -6277,6 +6277,15 @@ class L10nZh extends L10n {
 
   @override
   String get vt_silent_fallback => '已尝试静默安装，权限不足，改用系统安装器';
+
+  @override
+  String get ui_nav_back => '后退';
+
+  @override
+  String get ui_nav_forward => '前进';
+
+  @override
+  String get ui_custom_theme => '自定义';
 }
 
 /// The translations for Chinese, as used in Taiwan (`zh_TW`).
@@ -7563,7 +7572,7 @@ class L10nZhTw extends L10nZh {
   String get msgd58d230a => '藍寶石';
 
   @override
-  String get msg508b005e => '森林綠';
+  String get msg508b005e => '青檸綠';
 
   @override
   String get msgefdde083 => '日落桃';
@@ -9024,7 +9033,7 @@ class L10nZhTw extends L10nZh {
   String get ui_app_icon => '應用圖示';
 
   @override
-  String get ui_emerald_green => '翠綠';
+  String get ui_emerald_green => '霓虹青';
 
   @override
   String get ui_deep_red => '深紅';
@@ -12520,4 +12529,13 @@ class L10nZhTw extends L10nZh {
 
   @override
   String get vt_silent_fallback => '已嘗試靜默安裝，權限不足，改用系統安裝程式';
+
+  @override
+  String get ui_nav_back => '後退';
+
+  @override
+  String get ui_nav_forward => '前進';
+
+  @override
+  String get ui_custom_theme => '自訂';
 }

--- a/lib/providers/file_manager_provider.dart
+++ b/lib/providers/file_manager_provider.dart
@@ -2350,6 +2350,10 @@ class FileManagerProvider extends ChangeNotifier {
       'id': t.id,
       'currentPath': t.currentPath,
       'isPinned': t.isPinned,
+      // 持久化每个标签页的导航历史，避免重启后「后退/前进」全部变灰
+      // （v1.1.41 只存了 currentPath，恢复后历史栈为空）。
+      'pathHistory': t.pathHistory.take(60).toList(),
+      'historyIndex': t.historyIndex,
     }).toList();
     PreferencesService.saveSavedTabs(list);
   }
@@ -2531,11 +2535,17 @@ class FileManagerProvider extends ChangeNotifier {
   // 路径历史栈已迁移到 FolderTab，双窗口模式下每个 pane 拥有独立的历史，
   // 避免左/右窗口路径混在一起导致“在远程窗口按返回跳到本地路径”的问题。
 
-  /// 是否可“后退”。基于导航历史栈：历史栈中有上一个位置时才可用。
-  /// 参考 Windows 资源管理器：后退 = 回到历史上一个浏览位置，而非父目录。
+  /// 是否可“后退”。与 [goBack] 的真实能力保持一致：
+  /// - 历史栈中还有上一个位置时（historyIndex > 0）肯定可后退；
+  /// - 历史栈已耗尽但当前不在根目录时，[goBack] 会退到父目录，因此也算可后退。
+  ///
+  /// v1.1.41 只判断 historyIndex > 0，导致「标签页恢复后深层目录下按钮全灰、但
+  /// 系统返回键照样能返回」的矛盾表现。
   bool get canGoBack {
     final tab = activeTab;
-    return tab.historyIndex > 0;
+    if (tab.historyIndex > 0) return true;
+    if (tab.isRemote) return true;
+    return tab.currentPath.isNotEmpty && tab.currentPath != _rootPath;
   }
 
   /// 是否可“向上”。基于当前路径：只要不在存储根目录就可导航到父目录。
@@ -2583,6 +2593,15 @@ class FileManagerProvider extends ChangeNotifier {
 
   void _pushPathToHistory(String path) {
     final tab = activeTab;
+    if (path.isEmpty) return;
+    // 原地刷新 / 重复加载当前所在位置：历史栈完全不动。
+    // v1.1.41 会先截断前进历史再判断「是否与末项相同」，导致后退之后随便刷新
+    // 一下（下拉、自动重载、排序变更）前进历史就被静默清空，前进按钮莫名变灰。
+    if (tab.historyIndex >= 0 &&
+        tab.historyIndex < tab.pathHistory.length &&
+        tab.pathHistory[tab.historyIndex] == path) {
+      return;
+    }
     // 如果当前不是历史栈的最后一个，截断后面的历史（用户从中间位置导航到新路径）
     if (tab.historyIndex < tab.pathHistory.length - 1) {
       tab.pathHistory.removeRange(tab.historyIndex + 1, tab.pathHistory.length);
@@ -2590,8 +2609,39 @@ class FileManagerProvider extends ChangeNotifier {
     // 如果路径与当前最后一个不同，才添加
     if (tab.pathHistory.isEmpty || tab.pathHistory.last != path) {
       tab.pathHistory.add(path);
-      tab.historyIndex = tab.pathHistory.length - 1;
     }
+    tab.historyIndex = tab.pathHistory.length - 1;
+    // 限制历史长度，避免长时间使用无上限增长（同时持久化体积也受控）
+    const int maxHistory = 60;
+    if (tab.pathHistory.length > maxHistory) {
+      final removeCount = tab.pathHistory.length - maxHistory;
+      tab.pathHistory.removeRange(0, removeCount);
+      tab.historyIndex = (tab.historyIndex - removeCount).clamp(0, tab.pathHistory.length - 1).toInt();
+    }
+  }
+
+  /// 历史栈耗尽时的「后退到父目录」：把父目录插到当前位置**之前**，而不是追加到
+  /// 末尾。这样继续后退会一直向上，且「前进」能回到刚才的子目录，符合资源管理器
+  /// 的往返语义。v1.1.41 用 recordHistory:true 直接加载父目录，等于追加一条新历史
+  /// 并截断前进栈，会退化成「后退到父目录后再后退又回到子目录」的乒乓现象。
+  void _pushParentBeforeCurrent(String parent) {
+    final tab = activeTab;
+    if (tab.pathHistory.isEmpty) {
+      if (tab.currentPath.isNotEmpty) tab.pathHistory.add(tab.currentPath);
+      tab.historyIndex = 0;
+    }
+    if (tab.historyIndex < 0) tab.historyIndex = 0;
+    if (tab.historyIndex >= tab.pathHistory.length) {
+      tab.pathHistory.add(parent);
+      tab.historyIndex = tab.pathHistory.length - 1;
+      return;
+    }
+    // 历史栈当前位置与真实当前路径不一致（如标签页恢复后）时，先补齐当前路径
+    if (tab.pathHistory[tab.historyIndex] != tab.currentPath) {
+      tab.pathHistory.insert(tab.historyIndex + 1, tab.currentPath);
+    }
+    tab.pathHistory.insert(tab.historyIndex, parent);
+    // historyIndex 不变，插入后即指向父目录
   }
 
   /// 后退：回到导航历史栈中的上一个位置（参考 Windows 资源管理器）。
@@ -2622,7 +2672,8 @@ class FileManagerProvider extends ChangeNotifier {
       final parent = _parentOf(tab.currentPath);
       if (parent != tab.currentPath) {
         final exited = tab.currentPath;
-        await loadDirectory(parent, showLoading: false, recordHistory: true);
+        _pushParentBeforeCurrent(parent);
+        await loadDirectory(parent, showLoading: false, recordHistory: false);
         _highlightExited(exited);
         return true;
       }
@@ -2634,7 +2685,8 @@ class FileManagerProvider extends ChangeNotifier {
       final parent = _parentOf(tab.currentPath);
       if (parent == tab.currentPath) return false;
       final exited = tab.currentPath;
-      await loadDirectory(parent, showLoading: false, recordHistory: true);
+      _pushParentBeforeCurrent(parent);
+      await loadDirectory(parent, showLoading: false, recordHistory: false);
       _highlightExited(exited);
       return true;
     }
@@ -2967,10 +3019,20 @@ class FileManagerProvider extends ChangeNotifier {
     final savedTabsData = PreferencesService.getSavedTabs();
     if (savedTabsData.isNotEmpty) {
       final allTabs = savedTabsData.map((data) {
+        final hist = (data['pathHistory'] as List<dynamic>?)
+                ?.map((e) => e.toString())
+                .where((e) => e.isNotEmpty)
+                .toList() ??
+            <String>[];
+        final rawIdx = data['historyIndex'];
+        final idx = rawIdx is int ? rawIdx : -1;
+        final maxIdx = hist.isEmpty ? -1 : hist.length - 1;
         return FolderTab(
           id: data['id']?.toString() ?? DateTime.now().millisecondsSinceEpoch.toString(),
           currentPath: data['currentPath']?.toString() ?? initialPath,
           isPinned: data['isPinned'] ?? false,
+          pathHistory: hist,
+          historyIndex: idx.clamp(-1, maxIdx).toInt(),
         );
       }).toList();
 

--- a/lib/services/preferences_service.dart
+++ b/lib/services/preferences_service.dart
@@ -458,18 +458,32 @@ class PreferencesService {
     switch (name) {
       case 'orange': return const Color(0xFFFF6D00);
       case 'purple': return const Color(0xFF8E24AA);
-      case 'green': return const Color(0xFF00C853);
+      case 'green': return const Color(0xFF03FCE3);
       case 'red': return const Color(0xFFD50000);
       case 'gold': return const Color(0xFFFFD600);
       case 'pink': return const Color(0xFFFF2E93);
       case 'sapphire': return const Color(0xFF0F52BA);
-      case 'forest': return const Color(0xFF228B22);
+      case 'forest': return const Color(0xFFA9FC03);
       case 'peach': return const Color(0xFFFF7F50);
       case 'blue': return const Color(0xFF369FE7);
+      case 'custom':
+        return getCustomAccentColor();
       case 'dynamic':
       default:
         return const Color(0xFF369FE7);
     }
+  }
+
+  static const String _keyCustomAccentColor = 'custom_accent_color';
+
+  static Color getCustomAccentColor() {
+    final int? value = _prefs?.getInt(_keyCustomAccentColor);
+    if (value != null) return Color(value);
+    return const Color(0xFF03FCE3); // 默认霓虹青
+  }
+
+  static Future<void> saveCustomAccentColor(Color color) async {
+    await _prefs?.setInt(_keyCustomAccentColor, color.value);
   }
 
   static const String _keyFolderIconStyle = 'folder_icon_style';

--- a/lib/ui/screens/about_screen.dart
+++ b/lib/ui/screens/about_screen.dart
@@ -184,7 +184,7 @@ class AboutZenFileScreen extends StatelessWidget {
                   const SizedBox(height: 6),
                   // 版本号文本（硬编码，无需 l10n；以后升级版本只改这里）
                   Text(
-                    'v1.1.41',
+                    'v1.1.42',
                     style: TextStyle(
                       color: theme.colorScheme.onSurface.withOpacity(0.7),
                       fontSize: 13,
@@ -778,7 +778,7 @@ class AboutZenFileScreen extends StatelessWidget {
                   color: theme.colorScheme.primary.withOpacity(0.12),
                   borderRadius: BorderRadius.circular(20),
                 ),
-                child: Text('v1.1.41', style: TextStyle(color: theme.colorScheme.primary, fontSize: 13, fontWeight: FontWeight.bold, fontFamily: 'LexendDeca')),
+                child: Text('v1.1.42', style: TextStyle(color: theme.colorScheme.primary, fontSize: 13, fontWeight: FontWeight.bold, fontFamily: 'LexendDeca')),
               ),
               const SizedBox(width: 10),
               Text('2026-09-06', style: TextStyle(fontSize: 12, color: theme.colorScheme.onSurface.withOpacity(0.4))),

--- a/lib/ui/screens/directory_screen.dart
+++ b/lib/ui/screens/directory_screen.dart
@@ -382,7 +382,7 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
               Broken.arrow_left_2,
               color: provider.canGoBack ? theme.colorScheme.primary : theme.colorScheme.onSurface.withOpacity(0.3),
             ),
-            tooltip: L10n.of(context).ui_go_up,
+            tooltip: L10n.of(context).ui_nav_back,
             onPressed: provider.canGoBack ? () => _goBack(provider) : null,
           ),
           // 前进
@@ -391,8 +391,8 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
               Broken.arrow_right_3,
               color: provider.canGoForward ? theme.colorScheme.primary : theme.colorScheme.onSurface.withOpacity(0.3),
             ),
-            tooltip: L10n.of(context).msg6ed14da7,
-            onPressed: provider.canGoForward ? () => provider.goForward() : null,
+            tooltip: L10n.of(context).ui_nav_forward,
+            onPressed: provider.canGoForward ? () => _goForward(provider) : null,
           ),
           // 新建（复刻 AppBar 右上角的 PopupMenuButton）
           PopupMenuButton<String>(
@@ -612,6 +612,20 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
     } else if (_scrollController.hasClients) {
       final savedOffset = provider.getSavedScrollOffset(prevPath);
       _scrollController.jumpTo(savedOffset);
+    }
+  }
+
+  void _goForward(FileManagerProvider provider) async {
+    if (_scrollController.hasClients) {
+      provider.saveScrollOffset(provider.currentPath, _scrollController.offset);
+    }
+    final tab = provider.activeTab;
+    final nextPath = (tab.historyIndex + 1 < tab.pathHistory.length)
+        ? tab.pathHistory[tab.historyIndex + 1]
+        : '';
+    final ok = await provider.goForward();
+    if (ok && nextPath.isNotEmpty && _scrollController.hasClients) {
+      _scrollController.jumpTo(provider.getSavedScrollOffset(nextPath));
     }
   }
 

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -37,8 +37,19 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Si
   // 单指滑动追踪（用 Listener 而非 GestureDetector，避免手势竞技场冲突）
   Offset? _singleFingerStart;
   Offset? _singleFingerLast;
+  DateTime? _singleFingerStartTime;
   DateTime? _singleFingerLastTime;
+  // 本次手势期间是否真的发生过「文件长按拖拽」。v1.1.41 用 fileDragInteracting
+  // 在 down 阶段就掐断追踪，而该标志在任一文件项按下时即置位，导致落在文件上的
+  // 正常滑动永远不触发切页（浏览页绝大部分面积都被文件项覆盖）。改为只在拖拽
+  // 真正开始后才抑制，既保留防误触又恢复灵敏度。
+  bool _dragStartedDuringGesture = false;
   static const double _dualFingerSwipeThreshold = 30.0;
+  // 单指切页阈值：最小水平位移 / 免速度门槛的长位移 / 最小速度 / 边缘保护
+  static const double _swipeMinDistance = 64.0;
+  static const double _swipeLongDistance = 110.0;
+  static const double _swipeMinVelocity = 260.0;
+  static const double _swipeEdgeGuard = 36.0;
 
   @override
   void initState() {
@@ -253,15 +264,21 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Si
                 // 地址栏（面包屑）或分类网格的交互不触发页面左右滑动切换：
                 // 起点落在面包屑/类别图标上时，内层 Listener 已先置位对应标志，
                 // 此处跳过本次手势追踪（仅登记指针以便 up 时正常清理）。
-                if (fileProvider.breadcrumbInteracting || fileProvider.categoryReorderInteracting || fileProvider.tabBarInteracting || fileProvider.fileDragInteracting) {
+                // 注意：此处刻意不拦截 fileDragInteracting。该标志在任一文件项
+                // 按下时即置位，若在此 return，落在文件上的滑动（浏览页绝大部分
+                // 面积）将永远拿不到起始点，表现为「左右滑动切页失效/极不灵敏」。
+                // 真正的拖拽抑制下移到 move/up 阶段按「拖拽是否真的开始」判定。
+                if (fileProvider.breadcrumbInteracting || fileProvider.categoryReorderInteracting || fileProvider.tabBarInteracting) {
                   _activePointers[event.pointer] = event.position;
                   return;
                 }
                 _activePointers[event.pointer] = event.position;
                 if (_activePointers.length == 1) {
                   // 单指开始追踪
+                  _dragStartedDuringGesture = false;
                   _singleFingerStart = event.position;
                   _singleFingerLast = event.position;
+                  _singleFingerStartTime = DateTime.now();
                   _singleFingerLastTime = DateTime.now();
                 } else if (_activePointers.length == 2) {
                   // 双指开始追踪
@@ -278,8 +295,18 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Si
                 if (_activePointers.containsKey(event.pointer)) {
                   _activePointers[event.pointer] = event.position;
                 }
+                final fp = context.read<FileManagerProvider>();
                 // 分类页拖拽排序期间：放弃本次单指滑动追踪，避免误触切页
-                if (context.read<FileManagerProvider>().categoryReorderInteracting || context.read<FileManagerProvider>().fileDragInteracting) {
+                if (fp.categoryReorderInteracting) {
+                  _singleFingerStart = null;
+                  _singleFingerLast = null;
+                  return;
+                }
+                // 文件长按拖拽「真正开始」后：放弃本次滑动追踪。仅凭
+                // fileDragInteracting 不够——它在任一文件项按下时就置位，
+                // 会把正常滑动一并误杀（v1.1.41 切页迟钝的根因）。
+                if (fp.isDragging) {
+                  _dragStartedDuringGesture = true;
                   _singleFingerStart = null;
                   _singleFingerLast = null;
                   return;
@@ -320,34 +347,36 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Si
                 // 单指滑动处理（Listener 级别，不进入手势竞技场）
                 if (_activePointers.length == 1 && _singleFingerStart != null) {
                   final fileProvider = context.read<FileManagerProvider>();
-                  // 拖拽操作期间不处理滑动（文件拖拽 or 分类页类别排序拖拽）
-                  if (fileProvider.isDragging || fileProvider.categoryReorderInteracting || fileProvider.fileDragInteracting) {
-                    // 拖拽中，不处理滑动
+                  // 本次手势真的拖拽过文件 / 正在拖拽 / 分类排序拖拽：不切页
+                  if (_dragStartedDuringGesture || fileProvider.isDragging || fileProvider.categoryReorderInteracting) {
                     _singleFingerStart = null;
                     _singleFingerLast = null;
                   } else if (fileProvider.enableSingleFingerSwipe) {
                     final screenWidth = MediaQuery.of(context).size.width;
                     final startX = _singleFingerStart!.dx;
-                    // 屏幕边缘 48px 留给系统返回手势，不处理
-                    if (startX >= 48.0 && startX <= screenWidth - 48.0) {
-                      final endPos = _activePointers.values.first;
+                    // 屏幕边缘留给系统返回手势，不处理
+                    if (startX >= _swipeEdgeGuard && startX <= screenWidth - _swipeEdgeGuard) {
+                      final endPos = _singleFingerLast ?? event.position;
                       final dx = endPos.dx - _singleFingerStart!.dx;
                       final dy = endPos.dy - _singleFingerStart!.dy;
-                      // 垂直滑动主导时不触发左右切换（避免上下滚动误触）
-                      if (dy.abs() > dx.abs()) {
-                        // 上下滑动，不处理
-                      } else {
-                        // 最小滑动距离 80px，避免拖拽操作误触
-                        if (dx.abs() < 80.0) {
-                          // 滑动距离太小，不处理
-                        } else {
-                          final dt = DateTime.now().difference(_singleFingerLastTime!).inMilliseconds;
-                          final velocity = dt > 0 ? (dx / dt) * 1000 : 0.0; // px/s
-                          if (velocity < -300) {
+                      // 明显竖向滚动不切页；给 1.2 倍斜向容差，避免斜划被吞掉
+                      final horizontalDominant = dy.abs() <= dx.abs() * 1.2;
+                      // 最小水平位移 64px（v1.1.41 为 80px，偏迟钝）
+                      if (horizontalDominant && dx.abs() >= _swipeMinDistance) {
+                        // 速度按「整段手势时长」计算。v1.1.41 用的是「最后一次
+                        // move 到抬手」的间隔，抬手前稍作停顿速度就趋近 0，
+                        // 导致明明滑了很远也不切页——这是迟钝的第二大来源。
+                        final startT = _singleFingerStartTime ?? DateTime.now();
+                        final lastT = _singleFingerLastTime ?? DateTime.now();
+                        final totalMs = lastT.difference(startT).inMilliseconds;
+                        final velocity = totalMs > 0 ? (dx / totalMs) * 1000 : 0.0; // px/s
+                        // 快速轻扫 或 慢速长划（位移够大即忽略速度门槛）
+                        if (velocity.abs() >= _swipeMinVelocity || dx.abs() >= _swipeLongDistance) {
+                          if (dx < 0) {
                             // 向左滑动：分类页→浏览页，浏览页→快捷操作页面
                             if (_currentIndex == 0) _switchTab(1);
                             else if (_currentIndex == 1) _scaffoldKey.currentState?.openEndDrawer();
-                          } else if (velocity > 300) {
+                          } else {
                             // 向右滑动：快捷操作页面关闭、浏览页→分类页、分类页→抽屉
                             if (_currentIndex == 0) {
                               _scaffoldKey.currentState?.openDrawer();
@@ -370,6 +399,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Si
                 if (_activePointers.isEmpty) {
                   _singleFingerStart = null;
                   _singleFingerLast = null;
+                  _singleFingerStartTime = null;
+                  _dragStartedDuringGesture = false;
                   // 分类拖拽排序结束：恢复左右滑动切页能力。
                   // 必须在 home 手势处理完（含切页判定）后才清，否则会与 onReorderEnd
                   // 竞争，导致抬起瞬间标志已 false 而被误判为「非拖拽」触发切页。
@@ -384,6 +415,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver, Si
                 if (_activePointers.isEmpty) {
                   _singleFingerStart = null;
                   _singleFingerLast = null;
+                  _singleFingerStartTime = null;
+                  _dragStartedDuringGesture = false;
                   // 分类拖拽排序结束：恢复左右滑动切页能力。
                   // 必须在 home 手势处理完（含切页判定）后才清，否则会与 onReorderEnd
                   // 竞争，导致抬起瞬间标志已 false 而被误判为「非拖拽」触发切页。

--- a/lib/ui/screens/more_settings_screen.dart
+++ b/lib/ui/screens/more_settings_screen.dart
@@ -2535,12 +2535,12 @@ void _showThemePickerDialog(BuildContext context, FileManagerProvider fileManage
         {'key': 'dynamic', 'name': L10n.of(context).materialyou, 'color': Colors.teal},
         {'key': 'orange', 'name': L10n.of(context).msg05cff3ad, 'color': Color(0xFFFF6D00)},
         {'key': 'purple', 'name': L10n.of(context).msg5ed35657, 'color': Color(0xFF8E24AA)},
-        {'key': 'green', 'name': L10n.of(context).ui_emerald_green, 'color': const Color(0xFF00C853)},
+        {'key': 'green', 'name': L10n.of(context).ui_emerald_green, 'color': const Color(0xFF03FCE3)},
         {'key': 'red', 'name': L10n.of(context).ui_deep_red, 'color': const Color(0xFFD50000)},
         {'key': 'gold', 'name': L10n.of(context).msge74a7283, 'color': Color(0xFFFFD600)},
         {'key': 'pink', 'name': L10n.of(context).msg3904ba87, 'color': Color(0xFFFF2E93)},
         {'key': 'sapphire', 'name': L10n.of(context).msgd58d230a, 'color': Color(0xFF0F52BA)},
-        {'key': 'forest', 'name': L10n.of(context).msg508b005e, 'color': Color(0xFF228B22)},
+        {'key': 'forest', 'name': L10n.of(context).msg508b005e, 'color': Color(0xFFA9FC03)},
         {'key': 'peach', 'name': L10n.of(context).msgefdde083, 'color': Color(0xFFFF7F50)},
       ];
 
@@ -2598,6 +2598,37 @@ void _showThemePickerDialog(BuildContext context, FileManagerProvider fileManage
                       );
                     },
                   ),
+                  const Divider(height: 1),
+                  const SizedBox(height: 8),
+                  // 自定义主题颜色按钮
+                  ListTile(
+                    leading: Container(
+                      width: 36,
+                      height: 36,
+                      decoration: BoxDecoration(
+                        color: current == 'custom' ? PreferencesService.getCustomAccentColor() : theme.colorScheme.primary.withOpacity(0.15),
+                        shape: BoxShape.circle,
+                        border: Border.all(color: theme.colorScheme.primary.withOpacity(0.3), width: 1.5),
+                      ),
+                      child: Icon(
+                        Icons.colorize,
+                        color: current == 'custom' ? Colors.white : theme.colorScheme.primary,
+                        size: 20,
+                      ),
+                    ),
+                    title: Text(
+                      L10n.of(context).ui_custom_theme,
+                      style: TextStyle(fontWeight: current == 'custom' ? FontWeight.bold : FontWeight.normal),
+                    ),
+                    subtitle: current == 'custom'
+                        ? Text('#${PreferencesService.getCustomAccentColor().value.toRadixString(16).toUpperCase().padLeft(8, '0').substring(2)}', style: TextStyle(fontSize: 11, color: Colors.grey))
+                        : null,
+                    trailing: current == 'custom' ? Icon(Icons.radio_button_checked, color: theme.colorScheme.primary) : const Icon(Icons.chevron_right, color: Colors.grey),
+                    onTap: () {
+                      Navigator.pop(ctx);
+                      _showCustomColorPickerDialog(context, fileManager, theme);
+                    },
+                  ),
                 ],
               ),
             ),
@@ -2605,6 +2636,158 @@ void _showThemePickerDialog(BuildContext context, FileManagerProvider fileManage
         ),
       );
     },
+  );
+}
+
+void _showCustomColorPickerDialog(BuildContext context, FileManagerProvider fileManager, ThemeData theme) {
+  final initialColor = PreferencesService.getCustomAccentColor();
+  double r = initialColor.red.toDouble();
+  double g = initialColor.green.toDouble();
+  double b = initialColor.blue.toDouble();
+
+  final presetColors = [
+    const Color(0xFFE91E63), const Color(0xFFFF5722), const Color(0xFFFF9800),
+    const Color(0xFFFFC107), const Color(0xFFFFEB3B), const Color(0xFFCDDC39),
+    const Color(0xFF8BC34A), const Color(0xFF4CAF50), const Color(0xFF009688),
+    const Color(0xFF00BCD4), const Color(0xFF03A9F4), const Color(0xFF2196F3),
+    const Color(0xFF3F51B5), const Color(0xFF673AB7), const Color(0xFF9C27B0),
+    const Color(0xFF000000), const Color(0xFFFFFFFF), const Color(0xFF795548),
+  ];
+
+  showModalBottomSheet(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: theme.scaffoldBackgroundColor,
+    shape: const RoundedRectangleBorder(borderRadius: BorderRadius.vertical(top: Radius.circular(24))),
+    builder: (ctx) {
+      Color currentColor = Color.fromARGB(255, r.round(), g.round(), b.round());
+      return StatefulBuilder(
+        builder: (ctx, setState) {
+          return SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 20, horizontal: 16),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Center(
+                    child: Container(width: 40, height: 4, decoration: BoxDecoration(color: Colors.grey.withOpacity(0.3), borderRadius: BorderRadius.circular(2))),
+                  ),
+                  const SizedBox(height: 16),
+                  Text(L10n.of(context).ui_custom_theme, style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold)),
+                  const SizedBox(height: 16),
+                  // 颜色预览
+                  Center(
+                    child: Container(
+                      width: 80,
+                      height: 80,
+                      decoration: BoxDecoration(
+                        color: currentColor,
+                        shape: BoxShape.circle,
+                        border: Border.all(color: theme.colorScheme.onSurface.withOpacity(0.2), width: 2),
+                        boxShadow: [BoxShadow(color: currentColor.withOpacity(0.4), blurRadius: 12, spreadRadius: 2)],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Center(
+                    child: Text('#${currentColor.value.toRadixString(16).toUpperCase().padLeft(8, '0').substring(2)}', style: TextStyle(fontSize: 13, color: Colors.grey, fontFamily: 'monospace')),
+                  ),
+                  const SizedBox(height: 20),
+                  // 预设颜色
+                  Text('预设颜色', style: TextStyle(fontSize: 13, fontWeight: FontWeight.w600, color: theme.colorScheme.onSurface.withOpacity(0.7))),
+                  const SizedBox(height: 10),
+                  Wrap(
+                    spacing: 10,
+                    runSpacing: 10,
+                    children: presetColors.map((color) {
+                      final isSelected = color.value == currentColor.value;
+                      return GestureDetector(
+                        onTap: () {
+                          setState(() {
+                            r = color.red.toDouble();
+                            g = color.green.toDouble();
+                            b = color.blue.toDouble();
+                            currentColor = color;
+                          });
+                        },
+                        child: Container(
+                          width: 36,
+                          height: 36,
+                          decoration: BoxDecoration(
+                            color: color,
+                            shape: BoxShape.circle,
+                            border: isSelected ? Border.all(color: theme.colorScheme.primary, width: 3) : Border.all(color: theme.colorScheme.onSurface.withOpacity(0.15), width: 1),
+                          ),
+                          child: isSelected ? const Icon(Icons.check, color: Colors.white, size: 18) : null,
+                        ),
+                      );
+                    }).toList(),
+                  ),
+                  const SizedBox(height: 20),
+                  // RGB 滑块
+                  _buildColorSlider('R', r, Colors.red, (val) => setState(() { r = val; currentColor = Color.fromARGB(255, val.round(), g.round(), b.round()); })),
+                  _buildColorSlider('G', g, Colors.green, (val) => setState(() { g = val; currentColor = Color.fromARGB(255, r.round(), val.round(), b.round()); })),
+                  _buildColorSlider('B', b, Colors.blue, (val) => setState(() { b = val; currentColor = Color.fromARGB(255, r.round(), g.round(), val.round()); })),
+                  const SizedBox(height: 24),
+                  // 确认按钮
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: currentColor,
+                        foregroundColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(vertical: 14),
+                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                      ),
+                      onPressed: () async {
+                        await PreferencesService.saveCustomAccentColor(currentColor);
+                        if (fileManager.accentColorOption != 'custom') {
+                          fileManager.setAccentColorOption('custom');
+                        } else {
+                          fileManager.notifyListeners();
+                        }
+                        if (ctx.mounted) Navigator.pop(ctx);
+                      },
+                      child: Text('确认', style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold)),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      );
+    },
+  );
+}
+
+Widget _buildColorSlider(String label, double value, Color color, ValueChanged<double> onChanged) {
+  return Padding(
+    padding: const EdgeInsets.symmetric(vertical: 4),
+    child: Row(
+      children: [
+        SizedBox(
+          width: 24,
+          child: Text(label, style: TextStyle(fontSize: 13, fontWeight: FontWeight.bold, color: color)),
+        ),
+        Expanded(
+          child: Slider(
+            value: value,
+            min: 0,
+            max: 255,
+            divisions: 255,
+            activeColor: color,
+            inactiveColor: color.withOpacity(0.2),
+            onChanged: onChanged,
+          ),
+        ),
+        SizedBox(
+          width: 36,
+          child: Text(value.round().toString(), style: const TextStyle(fontSize: 12, fontFamily: 'monospace')),
+        ),
+      ],
+    ),
   );
 }
 

--- a/lib/ui/screens/video_player/video_player_screen.dart
+++ b/lib/ui/screens/video_player/video_player_screen.dart
@@ -142,6 +142,23 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
 
   // 解码方式：true=硬解(auto-safe), false=软解(no)，持久化保存
   bool _useHardwareDecode = true;
+
+  // ── 软解自适应画质档位 ────────────────────────────────────────────────
+  // v1.1.41 及之前软解固定写死 skiploopfilter=all（无条件关掉去块滤波），
+  // 低码率视频满屏块状伪影；同时 framedrop 因属性名写错（frame-drop）从未生效，
+  // 于是「糊」和「不流畅」两头都占。现改为：默认画质优先，运行时按解码器丢帧
+  // 计数自动逐级降质，流畅后再自动升回。
+  // 0=画质优先（不跳滤波 + spline36）→ 3=流畅优先（跳全部滤波 + bilinear）
+  int _swQualityTier = 0;
+  Timer? _frameDropWatchTimer;
+  int _frameDropCount = 0; // observeProperty 上报的最新解码器丢帧总数
+  int _frameDropBaseline = 0; // 上一个监测窗口结束时的计数值
+  int _cleanWindowsInARow = 0;
+  static const Duration _frameDropWindow = Duration(seconds: 2);
+  // 一个窗口（2s）内解码器丢帧达到该值即判定「跟不上」，降一级
+  static const int _frameDropDowngradeThreshold = 6;
+  // 连续多少个零丢帧窗口后升一级（20s 完全流畅才恢复画质，避免反复横跳）
+  static const int _cleanWindowsToUpgrade = 10;
   // 外挂字幕改用 Flutter overlay 渲染，确保字号/位置滑块对所有格式 100% 生效
   List<SubtitleCue> _externalCues = [];
   int _activeCueIndex = -1;
@@ -223,9 +240,11 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         await platform.setProperty('sub-font-size', _subtitleFontSize.round().toString());
         await platform.setProperty('sub-pos', _subtitlePosition.round().toString());
         await _applySubtitleBackgroundProps(platform);
-        // 软解模式额外启用解码性能优化
+        // 软解模式启用「画质优先 + 自适应降质」；硬解模式只提升输出缩放质量
         if (!_useHardwareDecode) {
           await _applySoftwareDecodeOptimizations(platform);
+        } else {
+          await _applyVideoOutputQuality(platform, highQuality: true);
         }
         // 音频均衡器：绑定到当前 mpv 原生播放器，恢复上次使用的预设
         try {
@@ -1432,9 +1451,15 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         await platform.setProperty('sub-font-size', _subtitleFontSize.round().toString());
         await platform.setProperty('sub-pos', _subtitlePosition.round().toString());
         await _applySubtitleBackgroundProps(platform);
-        // 切换到软解时启用性能优化
+        // 切换解码方式会重建 Player，旧的丢帧监测必须停掉（其 Timer 持有已废弃
+        // 的 platform 引用），否则会对着销毁中的播放器 setProperty。
+        _stopFrameDropWatch();
+        _swQualityTier = 0;
+        _cleanWindowsInARow = 0;
         if (!useHardware) {
           await _applySoftwareDecodeOptimizations(platform);
+        } else {
+          await _applyVideoOutputQuality(platform, highQuality: true);
         }
       }
     } catch (e) {
@@ -1504,25 +1529,121 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     });
   }
 
-  /// 软解模式性能优化：调整 mpv 属性减少 CPU 解码压力，降低卡顿。
-  /// 仅在 hwdec=no 时调用，硬解模式下不需要（GPU 已高效处理）。
+  /// 视频输出缩放质量。与解码方式无关——走的是 vo=gpu 的 shader，硬解/软解同样受益。
+  /// mpv 默认 scale=bilinear，480p/720p 全屏放大时明显发软，这是「糊」的第二来源。
+  Future<void> _applyVideoOutputQuality(NativePlayer platform,
+      {required bool highQuality}) async {
+    try {
+      // 亮度上采样：spline36 锐利且无明显振铃，GPU 开销中等
+      await platform.setProperty('scale', highQuality ? 'spline36' : 'bilinear');
+      // 色度上采样，与亮度保持一致
+      await platform.setProperty('cscale', highQuality ? 'spline36' : 'bilinear');
+      // 降采样（4K 片源 → 1080p 屏幕）用 mitchell，抗锯齿优于 spline36、不易振铃
+      await platform.setProperty('dscale', highQuality ? 'mitchell' : 'bilinear');
+    } catch (e) {
+      debugPrint('视频缩放质量设置失败: $e');
+    }
+  }
+
+  /// 软解模式性能优化：**画质优先起步 + 运行时自适应降质**。
+  ///
+  /// 仅供 hwdec=no 时调用，硬解模式下不需要（GPU 已高效处理）。
   Future<void> _applySoftwareDecodeOptimizations(NativePlayer platform) async {
     try {
       // 多线程解码：0=自动根据 CPU 核心数分配线程
       await platform.setProperty('vd-lavc-threads', '0');
-      // 跳过环路滤波：牺牲少量画质换取显著性能提升（软解卡顿的主要优化手段）
-      await platform.setProperty('vd-lavc-skiploopfilter', 'all');
-      // 允许丢帧保持音画同步：解码跟不上时优先保音频连续
-      await platform.setProperty('frame-drop', 'decoder');
+      // 解码队列：让解码在独立线程提前预解码，软解吞吐与平稳度提升明显
+      await platform.setProperty('vd-queue-enable', 'yes');
+      // 允许丢帧保持音画同步：解码跟不上时优先保音频连续。
+      // ⚠️ 属性名是 framedrop（无连字符）。此前写成 frame-drop，mpv 静默忽略、
+      //    异常被 try/catch 吞掉，这条「保流畅」的设置从未真正生效；而为了流畅
+      //    又无条件跳滤波牺牲画质，结果「糊」和「不流畅」两头都占。
+      await platform.setProperty('framedrop', 'decoder');
       // 增大解复用缓冲区，减少高码率视频卡顿
       await platform.setProperty('demuxer-max-bytes', '300M');
       await platform.setProperty('demuxer-readahead-secs', '60');
       // 增大播放缓存时长，减少网络视频卡顿
       await platform.setProperty('cache-secs', '60');
-      // 快速解码模式：启用 libavcodec 内部优化
-      await platform.setProperty('vd-lavc-fast', '1');
+      // 画质优先档位起步（不跳滤波 + spline36）
+      _swQualityTier = 0;
+      _cleanWindowsInARow = 0;
+      await _applyQualityTier(platform);
+      // 启动丢帧监测，卡顿时自动降质、恢复后自动升回
+      await _startFrameDropWatch(platform);
     } catch (e) {
       debugPrint('软解性能优化设置失败: $e');
+    }
+  }
+
+  /// 按当前档位应用「画质 ↔ 性能」相关属性。
+  /// tier: 0=不跳滤波（最清晰）1=跳非参考帧 2=跳双向帧 3=全跳（最快）
+  Future<void> _applyQualityTier(NativePlayer platform) async {
+    const skiploopfilter = ['none', 'nonref', 'bidir', 'all'];
+    final tier = _swQualityTier.clamp(0, 3);
+    try {
+      await platform.setProperty('vd-lavc-skiploopfilter', skiploopfilter[tier]);
+      // fast 会牺牲少量解码精度，仅在已经很吃力的最高档才启用
+      await platform.setProperty('vd-lavc-fast', tier >= 3 ? '1' : '0');
+      await _applyVideoOutputQuality(platform, highQuality: tier < 3);
+    } catch (e) {
+      debugPrint('画质档位($tier)应用失败: $e');
+    }
+  }
+
+  /// 观察 mpv 的解码器丢帧计数，按时间窗口自动升降画质档位。
+  Future<void> _startFrameDropWatch(NativePlayer platform) async {
+    _stopFrameDropWatch();
+    try {
+      _frameDropCount = 0;
+      _frameDropBaseline = 0;
+      await platform.observeProperty('decoder-frame-drop-count', (value) async {
+        final n = int.tryParse(value.trim()) ?? 0;
+        // 打开新片源时计数会归零，此时重置基线并回到画质优先，不误判为「流畅」
+        if (n < _frameDropCount) {
+          _frameDropBaseline = 0;
+          _swQualityTier = 0;
+          _cleanWindowsInARow = 0;
+        }
+        _frameDropCount = n;
+      });
+      _frameDropWatchTimer = Timer.periodic(
+        _frameDropWindow,
+        (_) => unawaited(_onFrameDropWindow()),
+      );
+    } catch (e) {
+      debugPrint('解码丢帧监测启动失败: $e');
+    }
+  }
+
+  void _stopFrameDropWatch() {
+    _frameDropWatchTimer?.cancel();
+    _frameDropWatchTimer = null;
+  }
+
+  /// 一个监测窗口结束：根据丢帧增量决定升档/降档。
+  Future<void> _onFrameDropWindow() async {
+    if (!mounted) return;
+    final platform = player.platform;
+    if (platform is! NativePlayer) return;
+    final delta = _frameDropCount - _frameDropBaseline;
+    _frameDropBaseline = _frameDropCount;
+    if (delta >= _frameDropDowngradeThreshold) {
+      // 解码持续跟不上：降一级画质换流畅
+      _cleanWindowsInARow = 0;
+      if (_swQualityTier < 3) {
+        _swQualityTier++;
+        await _applyQualityTier(platform);
+      }
+    } else if (delta == 0 && _frameDropCount > 0) {
+      // 完全不丢帧：连续多个窗口后才升回，避免在阈值附近反复横跳
+      _cleanWindowsInARow++;
+      if (_cleanWindowsInARow >= _cleanWindowsToUpgrade && _swQualityTier > 0) {
+        _swQualityTier--;
+        _cleanWindowsInARow = 0;
+        await _applyQualityTier(platform);
+      }
+    } else {
+      _cleanWindowsInARow = 0;
     }
   }
 

--- a/lib/ui/widgets/draggable_item.dart
+++ b/lib/ui/widgets/draggable_item.dart
@@ -31,49 +31,46 @@ class _DraggableItemState extends State<DraggableItem> {
 
   @override
   Widget build(BuildContext context) {
-    return Listener(
-      // 手指按下即抑制左右滑动切页，避免长按等待拖动的 600ms 内移动被误判为切页
-      onPointerDown: (_) {
-        context.read<FileManagerProvider>().setFileDragInteracting(true);
+    // 注意：这里刻意不再用 Listener 在「按下瞬间」就置位 fileDragInteracting。
+    // 文件项占浏览页绝大部分面积，一旦按下即抑制，落在文件上的普通左右滑动
+    // 会被全部误杀，表现为切页失效/极不灵敏（v1.1.41 问题）。
+    // 改为只在拖拽「真正开始」后（onDragStarted）才置位，结束时复位；
+    // 长按未触发拖动的普通点按/滑动完全不受影响。
+    return LongPressDraggable<DragPayload>(
+      data: widget.data,
+      feedback: widget.feedback,
+      dragAnchorStrategy: pointerDragAnchorStrategy,
+      delay: widget.delay,
+      onDragStarted: () {
+        _hasMoved = false;
+        final provider = context.read<FileManagerProvider>();
+        provider.setDragging(true);
+        provider.setFileDragInteracting(true);
+        widget.onDragStarted?.call();
       },
-      onPointerUp: (_) {
-        context.read<FileManagerProvider>().setFileDragInteracting(false);
+      onDragUpdate: (details) {
+        if (details.delta.dx.abs() > 20.0 || details.delta.dy.abs() > 20.0) {
+          _hasMoved = true;
+        }
       },
-      onPointerCancel: (_) {
-        context.read<FileManagerProvider>().setFileDragInteracting(false);
+      onDragEnd: (details) {
+        final provider = context.read<FileManagerProvider>();
+        provider.setDragging(false);
+        provider.setFileDragInteracting(false);
+        if (!_hasMoved && widget.onLongPress != null) {
+          widget.onLongPress!();
+        }
       },
-      child: LongPressDraggable<DragPayload>(
-        data: widget.data,
-        feedback: widget.feedback,
-        dragAnchorStrategy: pointerDragAnchorStrategy,
-        delay: widget.delay,
-        onDragStarted: () {
-          _hasMoved = false;
-          context.read<FileManagerProvider>().setDragging(true);
-          widget.onDragStarted?.call();
-        },
-        onDragUpdate: (details) {
-          if (details.delta.dx.abs() > 20.0 || details.delta.dy.abs() > 20.0) {
-            _hasMoved = true;
-          }
-        },
-        onDragEnd: (details) {
-          context.read<FileManagerProvider>().setDragging(false);
-          context.read<FileManagerProvider>().setFileDragInteracting(false);
-          if (!_hasMoved && widget.onLongPress != null) {
-            widget.onLongPress!();
-          }
-        },
-        onDraggableCanceled: (velocity, offset) {
-          context.read<FileManagerProvider>().setDragging(false);
-          context.read<FileManagerProvider>().setFileDragInteracting(false);
-        },
-        childWhenDragging: Opacity(
-          opacity: 0.35,
-          child: widget.child,
-        ),
+      onDraggableCanceled: (velocity, offset) {
+        final provider = context.read<FileManagerProvider>();
+        provider.setDragging(false);
+        provider.setFileDragInteracting(false);
+      },
+      childWhenDragging: Opacity(
+        opacity: 0.35,
         child: widget.child,
       ),
+      child: widget.child,
     );
   }
 }

--- a/lib/ui/widgets/zenfile_drawer.dart
+++ b/lib/ui/widgets/zenfile_drawer.dart
@@ -326,7 +326,7 @@ class _ZenFileDrawerState extends State<ZenFileDrawer> {
             Padding(
               padding: const EdgeInsets.symmetric(vertical: 12.0),
               child: Text(
-                'ZenFile v1.1.41',
+                'ZenFile v1.1.42',
                 style: TextStyle(fontSize: 11.5, color: theme.colorScheme.onSurface.withOpacity(0.4), fontWeight: FontWeight.w600),
               ),
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.41+68
+version: 1.1.42+69
 
 environment:
   sdk: ^3.11.5


### PR DESCRIPTION
> v1.1.41 已于 2026-09-06 发布，分割线以上为**历史归档，不再增改**。

> **分支约定（2026-09-07 起）**：`main` 受保护，仅放已验证发布版本（当前 v1.1.41 = `a257eeb`）；本 v1.1.42 全部 WIP 在 `dev` 分支开发与推送（`bc132c4` + 版本 bump `5d9ef8c`）。真机验证通过、要发布时再 bump 版本并合回 `main`。
> 本节内容将在 v1.1.42 发布时统一整理为更新日志（CHANGELOG / 关于页 / GitHub Release）。
> 新条目仍按**倒序**追加到本节最上方。
> **⚠️ 推送状态：2026-09-07 10:52 (GMT+8) 经用户明确要求，已将 v1.1.42 WIP（commit `bc132c4`，27 文件 / 784 增 132 删）推送至 `origin/main`（commit `a257eeb..bc132c4`）。本次**绕过**项目默认的「绝不推送、待真机验证」纪律，属用户主动要求的开发快照备份。代码未经真机验证，回滚以 `a257eeb` 为准。

---

## 视频播放器软解画质与流畅度优化
- 署名：WorkBuddy
- 日期时间：2026-09-07 09:52 (GMT+8)
- 类型：性能优化 + Bug 修复
- 根因（豆包 v1.1.41 软解管线 3 个问题）：
  1. **`framedrop` 属性名写错**：原 `_applySoftwareDecodeOptimizations` 写 `frame-drop`（带连字符），但 mpv 正确属性名是 `framedrop`（无连字符）。这条「解码跟不上就丢帧保音画同步」的设置被 mpv 静默忽略、异常被 try/catch 吞掉，**从未真正生效**。
  2. **无条件关闭环路滤波导致「糊」**：`vd-lavc-skiploopfilter=all` 一刀切关掉 H.264/HEVC 去块滤波，低码率视频满屏块状伪影，不分分辨率/码率。
  3. **缩放未做任何设置**：mpv 默认 `bilinear`，480p/720p 全屏放大发软。
  优化方案（用户选定：自适应降级 + spline36）：
  - 默认**画质优先**：不跳滤波（`skiploopfilter=none`）+ 缩放 `scale/cscale=spline36`、`dscale=mitchell`。
  - 运行期监测 `decoder-frame-drop-count`：2s 窗口内解码丢帧 ≥6 则降一级（`none→nonref→bidir→all`），流畅（连续 10 个零丢帧窗口≈20s）后自动升回。降档时在最高档才开 `vd-lavc-fast`。
  - 修掉 `framedrop` 属性名，启用 `vd-queue-enable=yes`（独立解码线程预解码）、`vd-lavc-threads=0`（按核心数自动分配）。
  - 硬解模式同样应用 spline36 缩放质量（此前硬解路径完全没动缩放）。
  - 切换解码方式重建 Player 时，旧的丢帧监测 Timer 先 `_stopFrameDropWatch()` 停掉，避免对着已销毁播放器 setProperty。
- 涉及文件：`lib/ui/screens/video_player/video_player_screen.dart`
- 待验证：① 软解 480p/720p 全屏放大明显更锐；② 软解高码率/4K 不再卡（丢帧时自动降质但画面不糊死）；③ 轻量视频始终不丢帧、保持最佳画质；④ 硬解模式清晰度同步提升；⑤ 切换硬/软解后无崩溃、不丢原播放进度；⑥ 高码率片源从卡顿回归流畅后画质自动恢复。
- 交接状态：已改未构建、未提交，待真机验证

## 浏览页底部操作栏「前进 / 后退」按钮逻辑优化
- 署名：WorkBuddy
- 日期时间：2026-09-07 09:16 (GMT+8)
- 类型：Bug 修复 + 优化
- 根因（4 处叠加）：
  1. **标签页持久化漏存历史栈**：`_persistTabs()` 只存了 `id/currentPath/isPinned`，`pathHistory` 与 `historyIndex` 未落盘。重启 App 后每个标签页历史栈为空 → 首次 `loadDirectory` 只压入当前路径 → `historyIndex == 0` → **后退、前进双灰**，即使正处在深层目录。而系统返回键走 `goBack()` 的父目录兜底分支照样能用，于是出现「返回键能用、按钮却灰着」的矛盾。
  2. **后退按钮可用性判定过窄**：`canGoBack` 只判 `historyIndex > 0`，与 `goBack()` 的真实能力（历史耗尽后退到父目录）不一致。
  3. **原地刷新静默清空前进历史**：`loadDirectory` 的 `recordHistory` 默认为 true，`_pushPathToHistory()` 会先 `removeRange` 截断前进历史、再判断「是否等于末项」。于是「后退一步 → 下拉刷新/自动重载」就会把前进历史清掉，**前进按钮莫名变灰**。
  4. **历史耗尽时后退→父目录会追加而非插入**：原实现用 `loadDirectory(parent, recordHistory: true)`，等于把父目录追加到历史末尾并截断前进栈，退化成「后退到父目录后再后退又回到子目录」的乒乓现象，前进也永远不可用。
- 修复：
  1. `_persistTabs()` 增加 `pathHistory`（上限 60 条）与 `historyIndex`；恢复标签页时读回并做 `clamp` 保护。
  2. `canGoBack` 改为「`historyIndex > 0` **或** 当前不在根目录（远程恒为 true）」，与 `goBack()` 实际行为对齐。
  3. `_pushPathToHistory()` 增加短路：目标路径等于「当前历史位置」时（原地刷新）**完全不动栈**，不再截断前进历史；并新增 60 条长度上限。
  4. 新增 `_pushParentBeforeCurrent(parent)`：历史耗尽时把父目录**插入到当前位置之前**，`goBack()` 的兜底分支改用 `recordHistory: false`。后退可持续向上，前进可回到子目录，符合资源管理器往返语义。
  5. 新增 `_goForward()`（directory_screen）：前进前后保存/恢复滚动位置，与后退、向上一致；此前前进直接调 `provider.goForward()`，没有任何滚动位置处理。
  6. **文案修正**：后退按钮 tooltip 原先误用 `ui_go_up`（"上一级"，与「向上」按钮完全重复），前进按钮误用 `msg6ed14da7`（"下一级"）。新增 l10n `ui_nav_back`（后退 / Back）与 `ui_nav_forward`（前进 / Forward），10 语言 ARB + generated dart 全量补齐。
- 涉及文件：`lib/providers/file_manager_provider.dart`、`lib/ui/screens/directory_screen.dart`、`lib/l10n/app_*.arb` ×10、`lib/l10n/generated/app_localizations*.dart` ×10
- 待验证：① 深层目录重启 App 后后退按钮不再灰；② 后退一步后下拉刷新，前进按钮仍可用；③ 后退到父目录后继续后退应逐级向上（不回子目录），前进能逐级回来；④ 根目录时后退仍为灰；⑤ 10 语言 tooltip 正确。
- 交接状态：已改未构建、未提交，待真机验证

---

## 浏览页左右滑动切页迟钝修复
- 署名：WorkBuddy
- 日期时间：2026-09-07 09:16 (GMT+8)
- 类型：Bug 修复（v1.1.41 拖放防误触引入的回归）
- 根因（2 处叠加）：
  1. **按下即抑制（主因）**：v1.1.41 为防拖放误触，在 `DraggableItem` 外层加了 `Listener.onPointerDown → setFileDragInteracting(true)`，而 `home_screen` 的滑动 `Listener.onPointerDown` 一旦见到该标志就 `return`，**不记录 `_singleFingerStart`**。由于文件项覆盖浏览页绝大部分面积，起点落在文件上的滑动永远拿不到起始点 → 不是「迟钝」，而是**几乎完全失效**，只有从空白/标题栏起手才生效。
  2. **速度口径错误**：`velocity = dx / (now - lastMoveTime)`，分母是「最后一次 move 到抬手」的停顿时长。抬手前稍作停顿（正常操作）速度就趋近 0，明明滑了 200px 也不触发。叠加 80px 的最小位移门槛，整体表现极其迟钝。
- 修复：
  1. `home_screen.onPointerDown` 不再因 `fileDragInteracting` 掐断追踪（保留 breadcrumb / tabBar / categoryReorder 这些真实冲突源）；抑制改在 move/up 阶段按「**拖拽是否真的开始**」判定，新增本地标志 `_dragStartedDuringGesture`。
  2. `DraggableItem` 去掉按下即置位的 `Listener`，改为只在 `onDragStarted` 置位、`onDragEnd/onDraggableCanceled` 复位。长按未触发拖动的普通点按与滑动完全不受影响，防误触目标仍然达成。
  3. 速度改为按**整段手势时长**计算；最小位移 80 → 64px；新增「位移 ≥ 110px 时忽略速度门槛」（慢速长划也能切页）；竖向判定给 1.2 倍斜向容差（原来 `dy > dx` 过严，斜划被吞）；边缘保护 48 → 36px。
- 涉及文件：`lib/ui/screens/home_screen.dart`、`lib/ui/widgets/draggable_item.dart`